### PR TITLE
Several changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .cask/
+local-report.json

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,10 @@
+2017-08-13  Saša Jovanić  <sasa@simplify.ba>
+
+	* Removed `.el` suffix in `undercover-init` file
+	* Added better testing instructions
+	* Updated README to reflect using emacsclient in TTY and GUI deamon
+	* Fixed problem with not removing of tooltip when there is nothing to show (slow checkers)
+
 2017-07-30  Saša Jovanić  <sasa@simplify.ba>
 
 	* Release 0.12.1

--- a/README.md
+++ b/README.md
@@ -45,7 +45,8 @@ Default value is "\u27a4 ": `➤ `.
 
 ## Usage with `flycheck-pos-tip`
 
-If you are planning to use `flycheck-pos-tip` with GUI Emacs and this extension on TTY, you can do it with following configuration:
+If you are planning to use `flycheck-pos-tip` with GUI Emacs and this
+extension on TTY, you can do it with following configuration:
 
 ``` elisp
 (eval-after-load 'flycheck
@@ -54,17 +55,29 @@ If you are planning to use `flycheck-pos-tip` with GUI Emacs and this extension 
     (flycheck-popup-tip-mode)))
 ```
 
+You can also do the following:
+
+``` elisp
+(setq flycheck-pos-tip-display-errors-tty-function #'flycheck-popup-tip-show-popup)
+(flycheck-pos-tip-mode)
+```
+
+That will help if you start Emacs in GUI, but run emacsclient in TTY.
+
 ## Contributing
 
 We welcome all kinds of contributions, whether you write patches, open pull
 requests, write documentation, help others with Flycheck issues, or just tell
 other people about your experiences with Flycheck.  Please take a look at our
-[Contributor’s Guide][contrib]
-for help and guidance about contributing to Flycheck.
+[Contributor’s Guide][contrib] for help and guidance about contributing to
+Flycheck.
 
 ### Running tests
 
-`cask exec buttercup -L . -L tests`
+`UNDERCOVER_FORCE=true UNDERCOVER_CONFIG='("*.el" (:report-file "local-report.json") (:send-report nil))' cask exec buttercup -L . -L tests`
+
+This will also generate `local-report.json` file where you can check if
+coverage dropped below 100%.
 
 ## License
 

--- a/flycheck-popup-tip.el
+++ b/flycheck-popup-tip.el
@@ -95,8 +95,8 @@
 
 (defun flycheck-popup-tip-show-popup (errors)
   "Display ERRORS, using popup.el library."
+  (flycheck-popup-tip-delete-popup)
   (when errors
-    (flycheck-popup-tip-delete-popup)
     (setq flycheck-popup-tip-object
           (popup-tip
            (flycheck-popup-tip-format-errors errors)

--- a/tests/test-flycheck-popup-tip.el
+++ b/tests/test-flycheck-popup-tip.el
@@ -27,7 +27,7 @@
 
 (require 'buttercup)
 (require 'flycheck)
-(require 'undercover-init.el)
+(require 'undercover-init)
 (require 'flycheck-popup-tip)
 
 ;;(post-command-hook)

--- a/tests/undercover-init.el
+++ b/tests/undercover-init.el
@@ -29,5 +29,5 @@
 (when (require 'undercover nil t)
   (undercover "*.el"))
 
-(provide 'undercover-init.el)
+(provide 'undercover-init)
 ;;; undercover-init ends here


### PR DESCRIPTION
- Removed `.el` suffix in `undercover-init` file
- Added better testing instructions
- Updated README to reflect using `emacsclient` in TTY and GUI deamon
- Fixed problem with removal of tooltip when there is nothing to show (slow checkers)